### PR TITLE
Update error message in login service

### DIFF
--- a/Microservices/login-service/services_logic.js
+++ b/Microservices/login-service/services_logic.js
@@ -122,7 +122,7 @@ async function getVerifyStatus(req, res) {
     const user = await User.findOne({username});
 
     if (!user) {
-        return res.status(401).json({error: 'User does not exist'});
+        return res.status(401).json({error: 'User does not exist!'});
     }
 
     verified = !!user.isVerified;


### PR DESCRIPTION
The login service error message for non-existing user has been altered to add more emphasis. This was done by adding an exclamation mark to the end of the existing message.